### PR TITLE
Make RestFlavor::from_path public

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -36,7 +36,8 @@ pub enum RestFlavor {
 }
 
 impl RestFlavor {
-    pub(crate) fn from_path(path: impl AsRef<Path>) -> Self {
+    /// Determine the REST flavor from the extension of a file path.
+    pub fn from_path(path: impl AsRef<Path>) -> Self {
         match path.as_ref().extension() {
             Some(ext) if ext == "http" => Self::Jetbrains,
             Some(ext) if ext == "rest" => Self::Vscode,


### PR DESCRIPTION
Howdy! This exposes `RestFlavor::from_path` public. I'm updating the importer in Slumber to be able to load from HTTP instead of a local file, so I can't use `RestFormat::parse_file` but I still want to detect the flavor from the URL.